### PR TITLE
Bump Azurite version &  Chart version & misc fixes

### DIFF
--- a/charts/azurite/CHANGELOG.md
+++ b/charts/azurite/CHANGELOG.md
@@ -11,6 +11,14 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
+## 1.10.0
+
+- [FEATURE] Allow specifying imagePullSecret in initJob
+- [FEATURE] make --loose configurable
+- [ENHANCEMENT] bump default Azurite version to 3.26.0
+- [CHANGE] move image version into values and adjust format to be compatible with renovate/dependabot
+- [CHANGE] don't hardcode initJob image, move image config into values.yaml instead
+
 ## 1.8.0
 
 - [CHANGE] Bump Azurite version to 3.21.0

--- a/charts/azurite/CHANGELOG.md
+++ b/charts/azurite/CHANGELOG.md
@@ -11,13 +11,15 @@ Entries should be ordered as follows:
 
 Entries should include a reference to the pull request that introduced the change.
 
-## 1.10.0
+## 2.0.0
 
+- ⚠️ BREAKING [CHANGE] Make Azurite image configuration compatible with renovate/dependabot
+- ⚠️ BREAKING [CHANGE] Disable --loose by default
 - [FEATURE] Allow specifying imagePullSecret in initJob
-- [FEATURE] make --loose configurable
-- [ENHANCEMENT] bump default Azurite version to 3.26.0
-- [CHANGE] move image version into values and adjust format to be compatible with renovate/dependabot
-- [CHANGE] don't hardcode initJob image, move image config into values.yaml instead
+- [FEATURE] Allow passing additional arguments to azurite process
+- [ENHANCEMENT] Make --loose and --disableProductStyleUrl configurable
+- [ENHANCEMENT] Move initJob image configuration into values.yaml
+- [ENHANCEMENT] Bump default Azurite version to 3.29.0
 
 ## 1.8.0
 

--- a/charts/azurite/Chart.yaml
+++ b/charts/azurite/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v2"
 name: "azurite"
 type: application
-version: "1.9.1"
-appVersion: "3.23.0"
+version: "1.10.0"
+appVersion: "3.26.0"
 description: "A lightweight server clone of Azure Storage that simulates most of the commands supported by it with minimal dependencies"
 home: "https://github.com/Azure/Azurite"

--- a/charts/azurite/Chart.yaml
+++ b/charts/azurite/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: "v2"
 name: "azurite"
 type: application
-version: "1.10.0"
-appVersion: "3.26.0"
+version: "2.0.0"
+appVersion: "3.29.0"
 description: "A lightweight server clone of Azure Storage that simulates most of the commands supported by it with minimal dependencies"
 home: "https://github.com/Azure/Azurite"

--- a/charts/azurite/templates/job.yaml
+++ b/charts/azurite/templates/job.yaml
@@ -16,11 +16,10 @@ spec:
     metadata:
       name: "{{ .Release.Name }}"
     spec:
-      {{- with .Values.image.pullSecrets }}
+      {{- with .Values.config.blobs.initJob.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      volumes:
       containers:
         - name: azurite-init-containers
           image: "{{ .Values.config.blobs.initJob.image.repository}}:{{ .Values.config.blobs.initJob.image.version | toString }}"

--- a/charts/azurite/templates/job.yaml
+++ b/charts/azurite/templates/job.yaml
@@ -16,9 +16,14 @@ spec:
     metadata:
       name: "{{ .Release.Name }}"
     spec:
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
       containers:
         - name: azurite-init-containers
-          image: lukaszczesniak/azure-storage-init-containers
+          image: "{{ .Values.config.blobs.initJob.image.repository}}:{{ .Values.config.blobs.initJob.image.version | toString }}"
           env:
             - name: AZURE_STORAGE_CONNECTION_STRING
               value: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1"

--- a/charts/azurite/templates/statefulset.yaml
+++ b/charts/azurite/templates/statefulset.yaml
@@ -56,13 +56,15 @@ spec:
         {{- toYaml .Values.statefulset.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.version | toString }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.version | default .Chart.AppVersion | toString }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - "azurite"
             - "-l"
             - "/data"
+            {{- if .Values.config.disableProductStyleUrl }}
             - "--disableProductStyleUrl"
+            {{- end }}
             {{- if .Values.config.loose }}
             - "--loose"
             {{- end }}
@@ -77,6 +79,9 @@ spec:
             {{- if .Values.config.tables.enabled }}
             - "--tableHost"
             - "0.0.0.0"
+            {{- end }}
+            {{- range .Values.config.arguments }}
+            - "{{ . }}"
             {{- end }}
           ports:
             {{- if .Values.config.blobs.enabled }}

--- a/charts/azurite/templates/statefulset.yaml
+++ b/charts/azurite/templates/statefulset.yaml
@@ -56,14 +56,16 @@ spec:
         {{- toYaml .Values.statefulset.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.name }}:{{ .Chart.AppVersion | toString }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.version | toString }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - "azurite"
             - "-l"
             - "/data"
             - "--disableProductStyleUrl"
+            {{- if .Values.config.loose }}
             - "--loose"
+            {{- end }}
             {{- if .Values.config.blobs.enabled }}
             - "--blobHost"
             - "0.0.0.0"

--- a/charts/azurite/values.yaml
+++ b/charts/azurite/values.yaml
@@ -7,16 +7,22 @@ nameOverride: null
 fullnameOverride: null
 
 image:
-  name: mcr.microsoft.com/azure-storage/azurite
+  repository: mcr.microsoft.com/azure-storage/azurite
+  version: 3.26.0
   pullPolicy: Always
   pullSecrets: []
 
 config:
+  # set to true to allow unsupported request headers and parameters
+  loose: false
   blobs:
     enabled: true
     ## https://github.com/viters/azure-storage-init-containers
     initJob:
       enabled: false
+      image: 
+        repository: lukaszczesniak/azure-storage-init-containers
+        version: latest
       containers:
         public: ""
         private: ""

--- a/charts/azurite/values.yaml
+++ b/charts/azurite/values.yaml
@@ -8,13 +8,22 @@ fullnameOverride: null
 
 image:
   repository: mcr.microsoft.com/azure-storage/azurite
-  version: 3.26.0
+  # Azurite version defaults to appVersion from Chart.yaml.
+  version: ""
   pullPolicy: Always
   pullSecrets: []
 
 config:
-  # set to true to allow unsupported request headers and parameters
+  # When using FQDN instead of IP in request Uri host,
+  # by default Azurite will parse storage account name from request Uri host.
+  # Force parsing storage account name from request Uri path with disableProductStyleUrl.
+  disableProductStyleUrl: true
+  # By default, Azurite will apply strict mode.
+  # Strict mode will block unsupported request headers or parameters.
+  # Disable it by enabling loose mode.
   loose: false
+  # Pass additional arguments to azurite process.
+  arguments: []
   blobs:
     enabled: true
     ## https://github.com/viters/azure-storage-init-containers
@@ -23,6 +32,7 @@ config:
       image: 
         repository: lukaszczesniak/azure-storage-init-containers
         version: latest
+        pullSecrets: []
       containers:
         public: ""
         private: ""


### PR DESCRIPTION
- [FEATURE] Allow specifying imagePullSecret in initJob
- [FEATURE] make --loose configurable
- [ENHANCEMENT] bump default Azurite version to 3.26.0
- [CHANGE] move image version into values and adjust format to be compatible with renovate/dependabot
- [CHANGE] don't hardcode initJob image, move image config into values.yaml instead